### PR TITLE
[fix] Modified regex for valid transaction parsing

### DIFF
--- a/cas2json/patterns.py
+++ b/cas2json/patterns.py
@@ -42,7 +42,7 @@ NAV = rf"NAV\s+on\s+{DATE}\s*:\s*INR\s*([\d,.]+)"
 FOLIO = r"Folio\s+No\s*:\s+([\d/\s]+\d)\s"
 # Transaction details
 # To not match text like "15-Sep-2025: 1% redeemed.... added exclusion for ':' "
-TRANSACTIONS = rf"^{DATE}\s*([^:]*?)(?=\s*{DATE}|\Z)"
+TRANSACTIONS = rf"^{DATE}(?!\s*:)\s*(.*?)(?=\s*{DATE}|\Z)"
 DESCRIPTION = r"^(.*?)\s+((?:[(-]*[\d,]+\.\d+\)*\s*)+)"
 CAS_TYPE = r"consolidated\s+account\s+(statement|summary)"
 DETAILED_DATE = rf"{DATE}\s+to\s+{DATE}"


### PR DESCRIPTION
The regex initially rejected all transaction containing `:` as per a rule to exclude transactions where `:` appears just after date like `12-May-2022:`
The new regex uses negative lookahead to reject only above case and accept all where `:` comes in description

Closes #17 